### PR TITLE
fix authentication token output bug (#2)

### DIFF
--- a/src/main/java/com/twilio/jenkins/TwilioNotifier.java
+++ b/src/main/java/com/twilio/jenkins/TwilioNotifier.java
@@ -378,9 +378,13 @@ public class TwilioNotifier extends Notifier {
                 listener.getLogger().println("Not notifying: " + build.getDisplayName());
 
             }
-        } catch (final Exception t) {
+            } catch (final Exception t) {
+            if(t.toString().contains("AuthToken")){
+                listener.getLogger().println("Exception: There was an error with your authentication token, please check your configuration settings.");
+            } else {
             listener.getLogger().println("Exception " + t);
         }
+    }
 
         return true;
     }


### PR DESCRIPTION
Added a check for AuthToken inside the exception within the catch.. The auth token was clearly visible during a failure. My master branch might be a bit messy.

Link to change: https://github.com/brandonflittner/twilio-notifier-plugin/commit/f37ed18dcd7ee07f52ade46cebba0ca7374f44e1#diff-288ad98af79914b5d150064ee134f8e6b3d69643f37e82d90a0b5fdeafafcda0

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [N/A] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [!] Ensure you have provided tests - that demonstrate feature works or fixes the issue |
        -  Unable to build the project (due to dependency errors).